### PR TITLE
add alert when only difference is error output

### DIFF
--- a/tester
+++ b/tester
@@ -73,11 +73,11 @@ for testfile in ${test_lists[*]}; do
 
 		printf $YELLOW
 		printf "Test %3s: " $i
-		if [[ "$MINI_OUTPUT" == "$BASH_OUTPUT" && "$MINI_EXIT_CODE" == "$BASH_EXIT_CODE" && "$MINI_ERROR_MSG" == "$BASH_ERROR_MSG"  && -z "$OUTFILES_DIFF" ]]; then
+		if [[ "$MINI_OUTPUT" == "$BASH_OUTPUT" && "$MINI_EXIT_CODE" == "$BASH_EXIT_CODE" && -z "$OUTFILES_DIFF" ]]; then
 			printf ✅
 			((ok++))
 			if [ "$MINI_ERROR_MSG" != "$BASH_ERROR_MSG" ]; then
-				printf ⚠️
+				printf "⚠️ "
 			fi
 		else
 			printf ❌


### PR DESCRIPTION
If the only difference is the error message, print an "alert" instead of an X for an error 
<img width="543" alt="image" src="https://user-images.githubusercontent.com/26127185/228245198-970063c5-b1b7-4ce3-bad9-1802421e79e1.png">
